### PR TITLE
Add meditation-based cooldown leveling system

### DIFF
--- a/src/main/java/org/skyforce/demon/CooldownManager.java
+++ b/src/main/java/org/skyforce/demon/CooldownManager.java
@@ -1,0 +1,43 @@
+package org.skyforce.demon;
+
+import org.bukkit.entity.Player;
+import org.skyforce.demon.player.PlayerDataManager;
+import org.skyforce.demon.player.PlayerProfile;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class CooldownManager {
+    private static PlayerDataManager dataManager;
+    private static final Map<UUID, Map<String, Long>> cooldowns = new HashMap<>();
+
+    public static void init(PlayerDataManager manager) {
+        dataManager = manager;
+    }
+
+    public static void addCooldown(Player player, String ability, int baseSeconds) {
+        PlayerProfile profile = dataManager.loadProfile(player.getUniqueId());
+        int level = profile.getMeditationLevel();
+        double reduction = 1 - 0.05 * (level - 1);
+        int effective = (int) Math.max(1, Math.round(baseSeconds * reduction));
+        cooldowns.computeIfAbsent(player.getUniqueId(), k -> new HashMap<>())
+                .put(ability.toLowerCase(), System.currentTimeMillis() + effective * 1000L);
+    }
+
+    public static boolean isOnCooldown(Player player, String ability) {
+        Map<String, Long> map = cooldowns.get(player.getUniqueId());
+        if (map == null) return false;
+        Long until = map.get(ability.toLowerCase());
+        return until != null && until > System.currentTimeMillis();
+    }
+
+    public static long getRemaining(Player player, String ability) {
+        Map<String, Long> map = cooldowns.get(player.getUniqueId());
+        if (map == null) return 0;
+        Long until = map.get(ability.toLowerCase());
+        if (until == null) return 0;
+        long diff = until - System.currentTimeMillis();
+        return diff > 0 ? diff / 1000L : 0;
+    }
+}

--- a/src/main/java/org/skyforce/demon/Main.java
+++ b/src/main/java/org/skyforce/demon/Main.java
@@ -27,11 +27,13 @@ import org.skyforce.demon.breathings.windbreathing.WindBreathingAbility;
 import org.skyforce.demon.breathings.windbreathing.WindBreathingListener;
 import org.skyforce.demon.commands.BloodDemonArtCommand;
 import org.skyforce.demon.commands.DMSCommand;
+import org.skyforce.demon.commands.MeditateCommand;
 import org.skyforce.demon.player.PlayerDataListener;
 import org.skyforce.demon.player.PlayerDataManager;
 import org.skyforce.demon.trainer.CreateTrainerCommand;
 import org.skyforce.demon.trainer.RemoveTrainerCommand;
 import org.skyforce.demon.trainer.TrainerListener;
+import org.skyforce.demon.CooldownManager;
 
 public final class Main extends JavaPlugin {
 
@@ -51,12 +53,14 @@ public final class Main extends JavaPlugin {
         getServer().getConsoleSender().sendMessage(logo);
 
         this.playerDataManager = new PlayerDataManager(this);
+        CooldownManager.init(playerDataManager);
         this.eventManager = new EventManager();
         this.getCommand("startevent").setExecutor(new StartEventCommand(eventManager));
         this.getCommand("removetrainer").setExecutor(new RemoveTrainerCommand());
         this.getCommand("createtrainer").setExecutor(new CreateTrainerCommand(this));
         getCommand("dms").setExecutor(new DMSCommand(playerDataManager));
         getCommand("sk").setExecutor(new BloodDemonArtCommand(this));
+        getCommand("meditate").setExecutor(new MeditateCommand(playerDataManager));
 
         getServer().getPluginManager().registerEvents(new EventWoolListener(eventManager), this);
         getServer().getPluginManager().registerEvents(new TrainerListener(playerDataManager), this);

--- a/src/main/java/org/skyforce/demon/breathings/mistbreathing/MistBreathingAbility.java
+++ b/src/main/java/org/skyforce/demon/breathings/mistbreathing/MistBreathingAbility.java
@@ -10,6 +10,7 @@ import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 import org.skyforce.demon.Main;
+import org.skyforce.demon.CooldownManager;
 
 import java.util.*;
 
@@ -20,12 +21,23 @@ public class MistBreathingAbility {
         this.player = player;
     }
 
+    private boolean tryUse(String key, int baseCooldown) {
+        if (CooldownManager.isOnCooldown(player, key)) {
+            long remaining = CooldownManager.getRemaining(player, key);
+            player.sendMessage("§cDiese Technik ist noch " + remaining + "s im Cooldown.");
+            return false;
+        }
+        CooldownManager.addCooldown(player, key, baseCooldown);
+        return true;
+    }
+
     public void useAbility() {
         // TODO: Implement the actual Mist Breathing ability effect
         player.sendMessage("You use Mist Breathing! (Effect not implemented yet)");
     }
 
     public void useFirstForm() {
+        if (!tryUse("FirstForm", 8)) return;
         player.sendMessage("§7☁ §b壱ノ型: 垂天遠霞 §7(First Form: Low Clouds, Distant Haze)");
 
         World world = player.getWorld();
@@ -82,7 +94,6 @@ public class MistBreathingAbility {
             }
         }
 
-        addCooldown(player, "FirstForm", 8);
     }
 
     /**
@@ -90,6 +101,7 @@ public class MistBreathingAbility {
      * Führt acht schnelle Nebelhiebe im Halbkreis vor dem Spieler aus.
      */
     public void useSecondForm() {
+        if (!tryUse("SecondForm", 6)) return;
         player.sendMessage("§7☁ §b弐ノ型: 八重霞 §7(Second Form: Eight-Layered Mist)");
 
         World world = player.getWorld();
@@ -139,7 +151,6 @@ public class MistBreathingAbility {
             }
         }
 
-        addCooldown(player, "SecondForm", 6);
     }
 
     Random random = new Random();
@@ -148,6 +159,7 @@ public class MistBreathingAbility {
      * A rising spiral of mist that follows the user's line of sight
      */
     public void useThirdForm() {
+        if (!tryUse("ThirdForm", 8)) return;
         player.sendMessage("§7☁ §b参ノ型: 霞散の飛沫 §7(Third Form: Scattering Mist Splash)");
 
         World world = player.getWorld();
@@ -259,8 +271,6 @@ public class MistBreathingAbility {
             }
         };
         spiralAnimation.runTaskTimer(Main.getPlugin(Main.class), 0L, 1L);
-
-        addCooldown(player, "ThirdForm", 8);
     }
 
     /**
@@ -268,6 +278,7 @@ public class MistBreathingAbility {
      * A swift dash attack with multiple slashes that appear like flowing mist
      */
     public void useFourthForm() {
+        if (!tryUse("FourthForm", 10)) return;
         player.sendMessage("§7☁ §b肆ノ型 移流斬 §7(Fourth Form: Shifting Flow Slash)");
 
         World world = player.getWorld();
@@ -387,13 +398,13 @@ public class MistBreathingAbility {
         // Apply speed effect to player during dash
         player.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, 15, 2, false, false));
 
-        addCooldown(player, "FourthForm", 10);
     }
     /**
      * Fifth Form: Sea of Clouds and Haze (伍ノ型 霞雲の海)
      * Creates a spherical sea of mist with omnidirectional slashes
      */
     public void useFifthForm() {
+        if (!tryUse("FifthForm", 15)) return;
         player.sendMessage("§7☁ §b伍ノ型 霞雲の海 §7(Fifth Form: Sea of Clouds and Haze)");
 
         World world = player.getWorld();
@@ -526,8 +537,6 @@ public class MistBreathingAbility {
         // Apply effects to player
         player.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, 80, 2, false, false));
         player.addPotionEffect(new PotionEffect(PotionEffectType.RESISTANCE, 80, 1, false, false));
-
-        addCooldown(player, "FifthForm", 15);
     }
 
     /**
@@ -535,6 +544,7 @@ public class MistBreathingAbility {
      * Rising spiral attack with multiple moon-shaped slashes
      */
     public void useSixthForm() {
+        if (!tryUse("SixthForm", 15)) return;
         player.sendMessage("§7☁ §b陸ノ型 月の霞消 §7(Sixth Form: Lunar Dispersing Mist)");
 
         World world = player.getWorld();
@@ -664,8 +674,6 @@ public class MistBreathingAbility {
         // Apply effects
         player.addPotionEffect(new PotionEffect(PotionEffectType.RESISTANCE, 40, 1, false, false));
         player.addPotionEffect(new PotionEffect(PotionEffectType.SLOW_FALLING, 60, 0, false, false));
-
-        addCooldown(player, "SixthForm", 15);
     }
 
     /**
@@ -673,6 +681,7 @@ public class MistBreathingAbility {
      * Muichiro's personal technique using tempo changes and mist illusions
      */
     public void useSeventhForm() {
+        if (!tryUse("SeventhForm", 20)) return;
         player.sendMessage("§7☁ §b漆ノ型 朧 §7(Seventh Form: Obscuring Clouds)");
 
         World world = player.getWorld();
@@ -807,13 +816,6 @@ public class MistBreathingAbility {
             }
         }.runTaskTimer(Main.getPlugin(Main.class), 0L, 1L);
 
-        addCooldown(player, "SeventhForm", 20);
-    }
-
-
-    private void addCooldown(Player player, String ability, int seconds) {
-        // Implementation of cooldown system
-        // You'll need to implement this based on your plugin's cooldown system
     }
 
     private Vector rotateAroundY(Vector v, double angle) {

--- a/src/main/java/org/skyforce/demon/commands/MeditateCommand.java
+++ b/src/main/java/org/skyforce/demon/commands/MeditateCommand.java
@@ -1,0 +1,43 @@
+package org.skyforce.demon.commands;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.skyforce.demon.player.PlayerDataManager;
+import org.skyforce.demon.player.PlayerProfile;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class MeditateCommand implements CommandExecutor {
+    private final PlayerDataManager playerDataManager;
+    private final Map<UUID, Long> meditating = new HashMap<>();
+
+    public MeditateCommand(PlayerDataManager manager) {
+        this.playerDataManager = manager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("Only players can meditate.");
+            return true;
+        }
+        Player player = (Player) sender;
+        UUID uuid = player.getUniqueId();
+        if (meditating.containsKey(uuid)) {
+            long start = meditating.remove(uuid);
+            long seconds = (System.currentTimeMillis() - start) / 1000L;
+            PlayerProfile profile = playerDataManager.loadProfile(uuid);
+            profile.addMeditationTime(seconds);
+            playerDataManager.saveProfile(profile);
+            player.sendMessage("§aMeditation beendet. Level: " + profile.getMeditationLevel());
+        } else {
+            meditating.put(uuid, System.currentTimeMillis());
+            player.sendMessage("§aMeditation gestartet. Nutze den Befehl erneut, um sie zu beenden.");
+        }
+        return true;
+    }
+}

--- a/src/main/java/org/skyforce/demon/player/PlayerDataManager.java
+++ b/src/main/java/org/skyforce/demon/player/PlayerDataManager.java
@@ -88,6 +88,9 @@ public class PlayerDataManager {
 
         profile.setNezuko(config.getBoolean("nezuko", false));
 
+        profile.setMeditationLevel(config.getInt("meditation_level", 1));
+        profile.setMeditationTime(config.getLong("meditation_time", 0));
+
         // Load techniques
         Set<String> techniques = new HashSet<>(config.getStringList("techniques"));
         for (String t : techniques) {
@@ -114,6 +117,8 @@ public class PlayerDataManager {
         }
 
         config.set("nezuko", profile.isNezuko());
+        config.set("meditation_level", profile.getMeditationLevel());
+        config.set("meditation_time", profile.getMeditationTime());
 
         // Save techniques
         Set<String> techs = new HashSet<>();

--- a/src/main/java/org/skyforce/demon/player/PlayerProfile.java
+++ b/src/main/java/org/skyforce/demon/player/PlayerProfile.java
@@ -10,6 +10,8 @@ public class PlayerProfile {
     private DemonType demonType;
     private boolean nezuko;
     private Set<TechniqueType> learnedTechniques;
+    private int meditationLevel;
+    private long meditationTime;
 
     public PlayerProfile(UUID uuid) {
         this.uuid = uuid;
@@ -17,6 +19,8 @@ public class PlayerProfile {
         this.demonType = null;
         this.nezuko = false;
         this.learnedTechniques = new HashSet<>();
+        this.meditationLevel = 1;
+        this.meditationTime = 0L;
     }
 
     public UUID getUuid() {
@@ -66,6 +70,30 @@ public class PlayerProfile {
 
     public boolean hasFlameBreathing() {
         return knowsTechnique(TechniqueType.FLAME_BREATHING);
+    }
+
+    public int getMeditationLevel() {
+        return meditationLevel;
+    }
+
+    public void setMeditationLevel(int meditationLevel) {
+        this.meditationLevel = meditationLevel;
+    }
+
+    public long getMeditationTime() {
+        return meditationTime;
+    }
+
+    public void setMeditationTime(long meditationTime) {
+        this.meditationTime = meditationTime;
+    }
+
+    public void addMeditationTime(long seconds) {
+        this.meditationTime += seconds;
+        while (meditationLevel < 10 && this.meditationTime >= 600) {
+            this.meditationTime -= 600;
+            this.meditationLevel++;
+        }
     }
 
     public boolean isDemon() {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -32,3 +32,8 @@ commands:
     usage: /dms <action>
     permission: demon.dms
   sk:
+  meditate:
+    description: Begin or end meditation to reduce cooldowns
+    usage: /meditate
+    permission: demon.meditate
+    permission-message: You do not have permission to meditate.


### PR DESCRIPTION
## Summary
- Add meditation level and time tracking in player profiles
- Introduce cooldown manager with level-based reduction and meditation command
- Wire new meditation command and cooldown manager into main plugin and mist breathing abilities

## Testing
- `mvn -q -e package` *(fails: Could not transfer artifact maven-resources-plugin due to Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688f12bcd594832494df09de3c2b4850